### PR TITLE
Fix URL typo ("hddm-dev" -> "hddm-devs").

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ setup(
     version="0.2a",
     author="Thomas V. Wiecki, Imri Sofer",
     author_email="thomas.wiecki@gmail.com",
-    url="http://github.com/hddm-dev/kabuki",
+    url="http://github.com/hddm-devs/kabuki",
     packages=["kabuki"],
     description="kabuki is a python toolbox that allows easy creation of hierarchical bayesian models for the cognitive sciences.",
     install_requires=['NumPy >=1.3.0', 'PyMC >=2.0', 'ordereddict >= 1.1'],


### PR DESCRIPTION
Took me a little while to find this repo from the PyPI entry because of this typo.
