### PR TITLE
Fixing occasional "Step-out procedure failed" bug

### DIFF
--- a/kabuki/step_methods.py
+++ b/kabuki/step_methods.py
@@ -380,7 +380,7 @@ class SliceStep(pm.Gibbs):
                 stoch.value = xl
                 iter += 1
 
-            assert iter < self.maxiter, "Step-out procedure failed"
+            assert iter <= self.maxiter, "Step-out procedure failed"
             self.neval += iter
 
             if self.verbose>2:
@@ -394,7 +394,7 @@ class SliceStep(pm.Gibbs):
                 stoch.value = xr
                 iter += 1
 
-        assert iter < self.maxiter, "Step-out procedure failed"
+        assert iter <= self.maxiter, "Step-out procedure failed"
         self.neval += iter
         if self.verbose>2:
             print('after %d iteration interval is [%.3f, %.3f]' % (iter, xl, xr))


### PR DESCRIPTION
I was getting a "step-out procedure failed" assertion error occasionally. I would run my code quickly in succession, and on the second run it would occasionally give this error. The error was definitely not related to the issues with the data brought up on the google group (missing or too-fast RTs, RTs in ms).

To fix it I changed the assertion error to allow "iter" to equal "self.max_iter"