### PR TITLE
Replacing .ix to .iloc / .loc

### DIFF
--- a/kabuki/analyze.py
+++ b/kabuki/analyze.py
@@ -145,7 +145,7 @@ def gelman_rubin(models):
         # Calculate mean for each chain
         samples = np.empty((num_chains, num_samples))
         for i,model in enumerate(models):
-            samples[i,:] = model.nodes_db.ix[name, 'node'].trace()
+            samples[i,:] = model.nodes_db.loc[name, 'node'].trace()
 
         R_hat_dict[name] = pm.diagnostics.gelman_rubin(samples)
 
@@ -255,14 +255,14 @@ def post_pred_compare_stats(sampled_stats, data_stats, evals=None):
     for stat_name in sampled_stats:
         #update NaN column with the no. of NaNs and remove them
         s = sampled_stats[stat_name]
-        results.ix[stat_name, 'NaN'] = sum(pd.isnull(s))
+        results.loc[stat_name, 'NaN'] = sum(pd.isnull(s))
         s = s[np.isfinite(s)]
         if len(s) == 0:
             continue
         #evaluate
         for eval_name, func in evals.items():
             value = func(s, data_stats[stat_name])
-            results.ix[stat_name, eval_name] = value
+            results.loc[stat_name, eval_name] = value
 
     return results.drop('NaN', axis=1)
 
@@ -321,7 +321,7 @@ def post_pred_gen(model, groupby=None, samples=500, append_data=False, progress_
         print("Sampling...")
 
     if groupby is None:
-        iter_data = ((name, model.data.ix[obs['node'].value.index]) for name, obs in model.iter_observeds())
+        iter_data = ((name, model.data.iloc[obs['node'].value.index]) for name, obs in model.iter_observeds())
     else:
         iter_data = model.data.groupby(groupby)
 

--- a/kabuki/hierarchical.py
+++ b/kabuki/hierarchical.py
@@ -523,7 +523,7 @@ class Hierarchical(object):
 
         # Set values of nodes
         for max_node in max_map.stochastics:
-            self.nodes_db.node.ix[max_node.__name__].set_value(max_node.value)
+            self.nodes_db.node.loc[max_node.__name__].set_value(max_node.value)
 
         return max_map
 
@@ -867,7 +867,7 @@ class Hierarchical(object):
         """
         group_nodes = self.get_group_nodes()
         for dep in self.depends_on.keys():
-            nodes = group_nodes.ix[group_nodes.knode_name == dep]
+            nodes = group_nodes.loc[group_nodes.knode_name == dep]
             if all(nodes.hidden == True):
                 continue
             analyze.plot_posterior_nodes(nodes['node'], *args, **kwargs)
@@ -946,7 +946,7 @@ class Hierarchical(object):
         return data_nodes[0]
 
     def __getitem__(self, name):
-        return self.nodes_db.ix[name]['node']
+        return self.nodes_db.loc[name]['node']
 
     @property
     def values(self):
@@ -964,7 +964,7 @@ class Hierarchical(object):
             new_values <dict> - dictionary of the format {'node_name1': new_value1, ...}
         """
         for (name, value) in new_values.items():
-            self.nodes_db.ix[name]['node'].set_value(value)
+            self.nodes_db.loc[name]['node'].set_value(value)
 
     def find_starting_values(self, *args, **kwargs):
         """Find good starting values for the different parameters by
@@ -1034,8 +1034,8 @@ class Hierarchical(object):
     def _approximate_map_subj(self, minimizer='Powell', use_basin=False, fall_to_simplex=True, debug=False, minimizer_kwargs=None, basin_kwargs=None):
         # Optimize subj nodes
         for subj_idx in self.nodes_db.subj_idx.dropna().unique():
-            stoch_nodes = self.nodes_db.ix[(self.nodes_db.subj_idx == subj_idx) & (self.nodes_db.stochastic == True)].node
-            obs_nodes = self.nodes_db.ix[(self.nodes_db.subj_idx == subj_idx) & (self.nodes_db.observed == True)].node
+            stoch_nodes = self.nodes_db.loc[(self.nodes_db.subj_idx == subj_idx) & (self.nodes_db.stochastic == True)].node
+            obs_nodes = self.nodes_db.loc[(self.nodes_db.subj_idx == subj_idx) & (self.nodes_db.observed == True)].node
             self._partial_optimize(stoch_nodes, obs_nodes, fall_to_simplex=fall_to_simplex, minimizer=minimizer, use_basin=use_basin, debug=debug, minimizer_kwargs=minimizer_kwargs, basin_kwargs=basin_kwargs)
 
     def approximate_map(self, individual_subjs=True, minimizer='Powell', use_basin=False, fall_to_simplex=True, cycles=1, debug=False, minimizer_kwargs=None, basin_kwargs=None):


### PR DESCRIPTION
Hi there, 
thanks for creating these nice packages (hddm, as well). I am just getting into it for a toy-project but it seems to be quite nice!
I am not sure if this is appreciated, but as of pandas 1.0 the use of `.ix` as index to `pd.DataFrames` has been removed (https://pandas.pydata.org/pandas-docs/version/1.0.0/whatsnew/v1.0.0.html), so I went through the kabuki (and hddm code) and tried to change the different kinds of `.ix` indices, here is the PR. 
Tests are passing and gelman_rubin seems to work as well. 

The easier fix could be to change the requirements to use a previous version of pandas. 

Best,
Simon
