### PR TITLE
fix of histogram plots

### DIFF
--- a/kabuki/analyze.py
+++ b/kabuki/analyze.py
@@ -475,7 +475,7 @@ def _plot_posterior_pdf_node(bottom_node, axis, value_range=None, samples=10, bi
 
     # Plot data
     if len(bottom_node.value) != 0:
-        axis.hist(bottom_node.value.values, normed=True, color='r',
+        axis.hist(bottom_node.value.values, density=True, color='r',
                   range=(value_range[0], value_range[-1]), label='data',
                   bins=bins, histtype='step', lw=2.)
 


### PR DESCRIPTION
when running `model.plot_posterior_predictive()` with HDDM python (v.0.8), I get the error message: `AttributeError: 'Polygon' object has no property 'normed'` (full stack below). 

A quick [google](https://github.com/googlecolab/colabtools/issues/1120) suggested that is due to matplotlib updating its plotting, and having replaced the keyword `normed`, with `density`. Indeed, when I changed `normed` to `density` in `kabuki.analyze`, this issue was resolved. 



Here the full stack trace:
```
/home/user/projects/dd/erc/experiments/RDM/ddm_tools.py in modelFitChecks(model, data, modeldir)
     68     plt.figure()
     69     # FIX SHOW ALL PLOTS OF A PARAMETER IF SPLIT ACROSS CONDITIONS
---> 70     model.plot_posterior_predictive(figsize=(14, 10))
     71     plt.savefig(os.path.join(modeldir,'post_pred.pdf'))
     72     plt.close()

/home/user/tools/miniconda3/envs/coconut/lib/python3.6/site-packages/hddm/models/base.py in plot_posterior_predictive(self, *args, **kwargs)
    766         if 'value_range' not in kwargs:
    767             kwargs['value_range'] = np.linspace(-5, 5, 100)
--> 768         kabuki.analyze.plot_posterior_predictive(self, *args, **kwargs)
    769 
    770     def plot_posterior_quantiles(self, *args, **kwargs):

/home/user/tools/miniconda3/envs/coconut/lib/python3.6/site-packages/kabuki/analyze.py in plot_posterior_predictive(model, plot_func, required_method, columns, save, path, figsize, format, num_subjs, **kwargs)
    558                 ax.set_title(str(bottom_node['subj_idx']))
    559 
--> 560             plot_func(bottom_node['node'], ax, **kwargs)
    561 
    562             if num_subjs is not None and i >= num_subjs:

/home/user/tools/miniconda3/envs/coconut/lib/python3.6/site-packages/kabuki/analyze.py in _plot_posterior_pdf_node(bottom_node, axis, value_range, samples, bins)
    478         axis.hist(bottom_node.value.values, normed=True, color='r',
    479                   range=(value_range[0], value_range[-1]), label='data',
--> 480                   bins=bins, histtype='step', lw=2.)
    481 
    482     axis.set_ylim(bottom=0) # Likelihood and histogram can only be positive

/home/user/.local/lib/python3.6/site-packages/matplotlib/__init__.py in inner(ax, data, *args, **kwargs)
   1563     def inner(ax, *args, data=None, **kwargs):
   1564         if data is None:
-> 1565             return func(ax, *map(sanitize_sequence, args), **kwargs)
   1566 
   1567         bound = new_sig.bind(ax, *args, **kwargs)

/home/user/.local/lib/python3.6/site-packages/matplotlib/axes/_axes.py in hist(self, x, bins, range, density, weights, cumulative, bottom, histtype, align, orientation, rwidth, log, color, label, stacked, **kwargs)
   6806             if patch:
   6807                 p = patch[0]
-> 6808                 p.update(kwargs)
   6809                 if lbl is not None:
   6810                     p.set_label(lbl)

/home/user/.local/lib/python3.6/site-packages/matplotlib/artist.py in update(self, props)
   1004 
   1005         with cbook._setattr_cm(self, eventson=False):
-> 1006             ret = [_update_property(self, k, v) for k, v in props.items()]
   1007 
   1008         if len(ret):

/home/user/.local/lib/python3.6/site-packages/matplotlib/artist.py in <listcomp>(.0)
   1004 
   1005         with cbook._setattr_cm(self, eventson=False):
-> 1006             ret = [_update_property(self, k, v) for k, v in props.items()]
   1007 
   1008         if len(ret):

/home/user/.local/lib/python3.6/site-packages/matplotlib/artist.py in _update_property(self, k, v)
   1000                 if not callable(func):
   1001                     raise AttributeError('{!r} object has no property {!r}'
-> 1002                                          .format(type(self).__name__, k))
   1003                 return func(v)
   1004 

AttributeError: 'Polygon' object has no property 'normed'
```